### PR TITLE
Fix function_clause error

### DIFF
--- a/src/eunit_teamcity.erl
+++ b/src/eunit_teamcity.erl
@@ -336,7 +336,7 @@ enter_new_test_item(Data, State) ->
     Depth = get_test_item_depth(Data),
     case get_current_group(State) of
         #group{depth = Depth} = CurrentGroup ->
-            end_group(CurrentGroup, State);
+            end_group(CurrentGroup, Data, State);
         _ -> State
     end.
 


### PR DESCRIPTION
This occurred when running 'rebar eunit' (no suites/tests specified),
and one of the test files contains only one test.

```
/usr/local/bin/rebar skip_deps=true eunit -C /private/var/folders/1j/0rpl0lf14jxfsxcwknt3wcg00000gn/T/eunit_teamcity6247470001686722430.tmp/rebar.config
Testing started at 12:12 PM ...
==> hoax (eunit)Empty test suite.
Empty test suite.
Empty test suite.
Empty test suite.
Empty test suite.
Empty test suite.

Test runner terminated. Reason: {error,function_clause,
                                 [{proplists,get_value,
                                   [desc,
                                    {group,"hoax_module_test",
                                     hoax_module_test,1},
                                    undefined],
                                   [{file,"proplists.erl"},{line,222}]},
                                  {eunit_teamcity,get_group_name,1,[]},
                                  {eunit_teamcity,create_group,1,[]},
                                  {eunit_teamcity,end_group,2,[]},
                                  {eunit_teamcity,do_begin_group,5,[]},
                                  {eunit_listener,call,3,
                                   [{file,"eunit_listener.erl"},{line,131}]},
                                  {eunit_listener,group,3,
                                   [{file,"eunit_listener.erl"},{line,87}]},
                                  {eunit_listener,group_loop,4,
                                   [{file,"eunit_listener.erl"},{line,92}]}]}

=ERROR REPORT==== 8-Nov-2013::12:12:52 ===
Error in process <0.131.0> with exit value: {function_clause,[{proplists,get_value,[desc,{group,"hoax_module_test",hoax_module_test,1},undefined],[{file,"proplists.erl"},{line,222}]},{eunit_teamcity,get_group_name,1,[]},{eunit_teamcity,create_group,1,[]},{eunit_teamcity... 
```
